### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/microsoft-openjdk`
 
-The Paketo Microsoft OpenJDK Buildpack is a Cloud Native Buildpack that provides the Microsoft OpenJDK implementations of its JDKs.
+The Paketo Buildpack for Microsoft OpenJDK is a Cloud Native Buildpack that provides the Microsoft OpenJDK implementations of its JDKs.
 
 This buildpack is designed to work in collaboration with other buildpacks which request contributions of JREs and JDKs.
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/microsoft-openjdk"
   id = "paketo-buildpacks/microsoft-openjdk"
   keywords = ["java", "jvm", "jre", "jdk"]
-  name = "Paketo Microsoft OpenJDK Buildpack"
+  name = "Paketo Buildpack for Microsoft OpenJDK"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Microsoft OpenJDK Buildpack' to 'Paketo Buildpack for Microsoft OpenJDK'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
